### PR TITLE
#116 Direction des TDC depuis la base

### DIFF
--- a/mviewer/maddog/addons/maddog/js/utils/tdcUtils.js
+++ b/mviewer/maddog/addons/maddog/js/utils/tdcUtils.js
@@ -37,6 +37,10 @@ const tdcUtils = (function () {
                                 radialDistance.value = p?.radial_distance;
                                 tdcUtils.onParamChange(radialDistance);
                             }
+                            if (p.hasOwnProperty("direction")) {
+                                radialDirection.value = p.direction;
+                                tdcUtils.onParamChange(radialDirection);
+                            }
                         })
                 );
         },


### PR DESCRIPTION
Cette PR permet de configurer par défaut au clic sur un site, la valeur de l'orientation du TDC.


**Attention @mrouan :

Il semble que cette valeur ne soit pas forcément bien renseigné ou inversée dans le WPS.**

Car par défaut, pour BOUTRO, la valeur orientation est à `false` et provoque le calcule de l'orientation vers le nord. Alors que cette valeur est correcte pour VOUGO.